### PR TITLE
remove namespace

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,7 +16,7 @@ appVersion: "latest"
 
 dependencies:
   - name: ipsec-vpn-server
-    version: 1.1.2
+    version: 1.1.4
     repository: "https://helm.task.media/"
 
 icon: https://media.task.media/images/logo.png

--- a/templates/secret-ios-profile.yaml
+++ b/templates/secret-ios-profile.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "vpn-ios-profile.fullname" . }}-ios-profile
-  namespace: {{ .Values.namespace }}
 stringData:
 {{- range (index .Values "ipsec-vpn-server" "users") }}
   vpn-{{ .username }}.mobileconfig: |-

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,4 @@
 fullnameOverride: &global-fullnameOverride vpn-ios-profile
-namespace: &global-namespace vpn
 
 trusted_ssids:
   - myhome-network
@@ -10,7 +9,6 @@ ipsec-vpn-server:
   # Overwrite VPN configuration of ipsec-vpn-server chart
   # recommended to overwrite name when using sealed-secrets
   fullnameOverride: *global-fullnameOverride
-  namespace: *global-namespace
 
   vpn:
     dns_name: vpn.example.com


### PR DESCRIPTION
The specification of a namespace is not required - that should be set automatically when installing the Helm chart