### PR TITLE
add maintainer to charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,6 +8,10 @@ keywords:
   - ios
   - mobileconfig
 
+maintainers:
+  - name: taskmedia
+    url: https://task.media
+
 type: application
 
 version: 0.2.3


### PR DESCRIPTION
Missed maintainer in Helm chart - see [workflow run](https://github.com/taskmedia/helm_vpn-ios-profile/runs/6276800978?check_suite_focus=true)