### PR TITLE
add test installation in pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,10 @@ jobs:
       - name: create kind cluster
         uses: helm/kind-action@v1.2.0
 
+      - name: setup chart dependency repository
+        run: |
+          helm repo add taskmedia https://helm.task.media/
+
       - name: run chart-testing (install)
         run: |
           ct install \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,3 +35,11 @@ jobs:
         run: |
           ct lint \
             --charts ./
+
+      - name: create kind cluster
+        uses: helm/kind-action@v1.2.0
+
+      - name: run chart-testing (install)
+        run: |
+          ct install \
+            --charts ./


### PR DESCRIPTION
To test the installation of the Helm chart (not only lint the chart) this will create a test cluster and test the installation.

The kind test cluster will then be used to install the application and also perform tests from `helm test *`.