### PR TITLE
feat: add endpoint to download iOS profiles

### DIFF
--- a/templates/secret-ios-profile.yaml
+++ b/templates/secret-ios-profile.yaml
@@ -4,6 +4,26 @@ kind: Secret
 metadata:
   name: {{ include "vpn-ios-profile.fullname" . }}-ios-profile
 stringData:
+  index.html: |-
+    <html>
+    <head>
+      <title>VPN configuration profiles</title>
+    </head>
+    <style>
+    body {
+      font-family: Verdana, sans-serif;
+    }
+    </style>
+    <body>
+      <h1>VPN configuration profiles (iOS)</h1>
+      <ul>
+      {{- range (index .Values "ipsec-vpn-server" "users") }}
+        <li><a href="/vpn-{{ .username }}.mobileconfig">{{ .username }}</a></li>
+      {{- end }}
+      </ul>
+    </body>
+    </html>
+
 {{- range (index .Values "ipsec-vpn-server" "users") }}
   vpn-{{ .username }}.mobileconfig: |-
     <?xml version="1.0" encoding="UTF-8"?>

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.web.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vpn-ios-profile.fullname" . }}-web
+  labels:
+    {{- include "vpn-ios-profile.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vpn-ios-profile.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vpn-ios-profile.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+      containers:
+        - name: web
+          image: nginxinc/nginx-unprivileged
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+          - name: iosprofiles
+            mountPath: /usr/share/nginx/html
+            readOnly: true
+      volumes:
+      - name: iosprofiles
+        secret:
+          secretName: {{ include "vpn-ios-profile.fullname" . }}-ios-profile
+          # defaultMode: 0444
+{{- end }}

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -24,6 +24,14 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
           volumeMounts:
           - name: iosprofiles
             mountPath: /usr/share/nginx/html
@@ -32,5 +40,5 @@ spec:
       - name: iosprofiles
         secret:
           secretName: {{ include "vpn-ios-profile.fullname" . }}-ios-profile
-          # defaultMode: 0444
+          defaultMode: 0444
 {{- end }}

--- a/templates/web/ingress.yaml
+++ b/templates/web/ingress.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.web.ingressroute.enabled }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "vpn-ios-profile.fullname" . }}-web
+spec:
+  entryPoints:
+    - websecure
+  routes:
+  - kind: Rule
+    match: Host(`{{ .Values.web.ingressroute.host }}`)
+    {{- if and .Values.web.ingressroute.enabled (and .Values.web.ingressroute.username .Values.web.ingressroute.password) }}
+    middlewares:
+    - name: {{ include "vpn-ios-profile.fullname" . }}-web-basicauth
+    {{- end }}
+    services:
+    - kind: Service
+      name: {{ include "vpn-ios-profile.fullname" . }}-web
+      port: 80
+  tls:
+    certResolver: le-prod
+{{- end }}

--- a/templates/web/middleware.yaml
+++ b/templates/web/middleware.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.web.ingressroute.enabled (and .Values.web.ingressroute.username .Values.web.ingressroute.password) }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "vpn-ios-profile.fullname" . }}-web-basicauth
+spec:
+  basicAuth:
+    secret: {{ include "vpn-ios-profile.fullname" . }}-web-basicauth
+{{- end }}

--- a/templates/web/secret-basicauth.yaml
+++ b/templates/web/secret-basicauth.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.web.ingressroute.enabled (and .Values.web.ingressroute.username .Values.web.ingressroute.password) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "vpn-ios-profile.fullname" . }}-web-basicauth
+type: kubernetes.io/basic-auth
+stringData:
+  username: {{ .Values.web.ingressroute.username }}
+  password: {{ .Values.web.ingressroute.password }}
+{{- end }}

--- a/templates/web/service.yaml
+++ b/templates/web/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.web.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vpn-ios-profile.fullname" . }}-web
+  labels:
+    {{- include "vpn-ios-profile.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "vpn-ios-profile.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -25,3 +25,16 @@ iosprofile:
   PayloadDescription: "This iOS Profile provides VPN connection to %dns_name with the user %username"
   PayloadIdentifier: "%dns_name.%username.ios-profile"
   PayloadOrganization: "%dns_name"
+
+web:
+  # Enable web server to host iOS profiles
+  enabled: false
+
+  ingressroute:
+    # ingressroute to host iOS profiles at
+    host: ios.vpn.example.com
+
+    # basic auth credentials - username
+    username: ""
+    # basic auth credentials - password
+    password: ""


### PR DESCRIPTION
Adding a endpoint (website) to download all profiles.

Can be disabled if e.g. all profiles are downloaded.
Password protection available with basic auth thought traefik middleware.