### PR TITLE
chore: use alias for helm dependency chart 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/charts/*.tgz
 
 Chart.lock
+
+values-*.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 Chart.lock
 
 values-*.yaml
+
+## Ignore certs directory
+certs/*

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,16 +3,16 @@ name: vpn-ios-profile
 description: Deploy a VPN server in K8s with provided iOS profile
 home: https://helm.task.media/vpn-ios-profile/
 keywords:
-  - vpn
-  - ipsec
-  - ios
-  - mobileconfig
+- vpn
+- ipsec
+- ios
+- mobileconfig
 
 maintainers:
-  - name: taskmedia
-    url: https://task.media
+- name: taskmedia
+  url: https://task.media
 sources:
-  - https://github.com/taskmedia/helm_vpn-ios-profile
+- https://github.com/taskmedia/helm_vpn-ios-profile
 
 type: application
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,8 +21,9 @@ version: 0.2.3
 appVersion: "latest"
 
 dependencies:
-  - name: ipsec-vpn-server
-    version: 1.1.4
-    repository: "https://helm.task.media/"
+- alias: vpnserver
+  name: ipsec-vpn-server
+  version: 1.1.4
+  repository: "https://helm.task.media/"
 
 icon: https://media.task.media/images/logo.png

--- a/templates/certs.tpl
+++ b/templates/certs.tpl
@@ -5,7 +5,7 @@ Add custom certificates to iOS profile
 {{- /* Generate list of users certificates */}}
 {{- $username := .user.username -}}
 {{- $certs := .root.Values.certs  -}}
-{{- range (index .root.Values "ipsec-vpn-server" "users") -}}
+{{- range .root.Values.vpnserver.users -}}
 {{- if and (eq .username $username) (.certs) }}
 {{- $certs = concat $certs .certs }}
 {{- end }}

--- a/templates/secret-ios-profile.yaml
+++ b/templates/secret-ios-profile.yaml
@@ -1,4 +1,4 @@
-{{- $dns_name := (index $.Values "ipsec-vpn-server" "vpn" "dns_name") -}}
+{{- $dns_name := $.Values.vpnserver.vpn.dns_name -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,14 +17,14 @@ stringData:
     <body>
       <h1>VPN configuration profiles (iOS)</h1>
       <ul>
-      {{- range (index .Values "ipsec-vpn-server" "users") }}
+      {{- range .Values.vpnserver.users }}
         <li><a href="/vpn-{{ .username }}.mobileconfig">{{ .username }}</a></li>
       {{- end }}
       </ul>
     </body>
     </html>
 
-{{- range (index .Values "ipsec-vpn-server" "users") }}
+{{- range .Values.vpnserver.users }}
   {{ $vpnList := ((include "vpn.list" (dict "root" $ "user" . )) | fromYamlArray) }}
   vpn-{{ .username }}.mobileconfig: |-
     <?xml version="1.0" encoding="UTF-8"?>

--- a/templates/tests/test-connection.yaml
+++ b/templates/tests/test-connection.yaml
@@ -19,7 +19,7 @@ spec:
           apk add diffutils
 
           expected_file="/test_expected/vpn-vpn.mobileconfig"
-          actual_file="/test/vpn-{{ print (index .Values "ipsec-vpn-server" "users" 0 "username") }}.mobileconfig"
+          actual_file="/test/vpn-{{ print (index .Values.vpnserver.users 0 "username") }}.mobileconfig"
 
           # ensure path is present
           mkdir -p $(dirname $expected_file)

--- a/templates/vpn.tpl
+++ b/templates/vpn.tpl
@@ -2,12 +2,12 @@
 VPN list of concatenated VPNs for a user.
 */}}
 {{- define "vpn.list" -}}
-- address: {{ print (index .root.Values "ipsec-vpn-server" "vpn" "dns_name") }}
-  psk: {{ print (index .root.Values "ipsec-vpn-server" "vpn" "psk") }}
+- address: {{ print .root.Values.vpnserver.vpn.dns_name }}
+  psk: {{ print .root.Values.vpnserver.vpn.psk }}
   username: {{ .user.username }}
   password: {{ .user.password }}
 {{- $username := .user.username -}}
-{{- range (index .root.Values "ipsec-vpn-server" "users") -}}
+{{- range .root.Values.vpnserver.users -}}
 {{- if and (eq .username $username) (.additionalVpns) }}
 {{ toYaml .additionalVpns }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: &global-fullnameOverride vpn-ios-profile
 
 # values of dependency chart ipsec-vpn-server
-ipsec-vpn-server:
+vpnserver:
   # Overwrite VPN configuration of ipsec-vpn-server chart
   # recommended to overwrite name when using sealed-secrets
   fullnameOverride: *global-fullnameOverride


### PR DESCRIPTION
When using an alias it is more easy to access the values

and some format issues