### PR TITLE
feat: generate uuid with sha1sum

### DIFF
--- a/templates/certs.tpl
+++ b/templates/certs.tpl
@@ -24,11 +24,11 @@ Add custom certificates to iOS profile
   <key>PayloadDisplayName</key>
   <string>{{ .name }}</string>
   <key>PayloadIdentifier</key>
-  <string>com.apple.security.root.{{ uuidv4 }}</string>
+  <string>com.apple.security.root.{{ sha1sum (printf "cert-%s" .name) }}</string>
   <key>PayloadType</key>
   <string>com.apple.security.root</string>
   <key>PayloadUUID</key>
-  <string>{{ uuidv4 }}</string>
+  <string>{{ sha1sum (printf "cert-%s" .name) }}</string>
   <key>PayloadVersion</key>
   <integer>1</integer>
 </dict>

--- a/templates/wifi.tpl
+++ b/templates/wifi.tpl
@@ -22,11 +22,11 @@ WiFi connections
   <key>PayloadDisplayName</key>
   <string>Wi-Fi {{ .wifi.ssid }}</string>
   <key>PayloadIdentifier</key>
-  <string>com.apple.wifi.managed.{{ uuidv4 }}</string>
+  <string>com.apple.wifi.managed.{{ sha1sum (printf "wifi-%s" .wifi.ssid) }}</string>
   <key>PayloadType</key>
   <string>com.apple.wifi.managed</string>
   <key>PayloadUUID</key>
-  <string>{{ uuidv4 }}</string>
+  <string>{{ sha1sum (printf "wifi-%s" .wifi.ssid) }}</string>
   <key>PayloadVersion</key>
   <integer>1</integer>
   <key>ProxyType</key>


### PR DESCRIPTION
use sha instead of generated uuid to ensure id does not change every deployment.