### PR TITLE
chore: ensure vpn.name is also used for displayname

### DIFF
--- a/templates/vpn.always.tpl
+++ b/templates/vpn.always.tpl
@@ -9,7 +9,7 @@ VPN will always reconnect on this mode.
   <string>{{ .vpn.name | default .vpn.address }} always</string>
 
   <key>PayloadDisplayName</key>
-  <string>{{ .vpn.address }} always</string>
+  <string>{{ .vpn.name | default .vpn.address }} always</string>
 
   <key>PayloadIdentifier</key>
   <string>{{ .vpn.address }}.{{ .vpn.username }}.always</string>

--- a/templates/vpn.manual.tpl
+++ b/templates/vpn.manual.tpl
@@ -8,7 +8,7 @@ Connection can be disabled by this setting and enabled for a period of time if n
   <string>{{ .vpn.name | default .vpn.address }} manual</string>
 
   <key>PayloadDisplayName</key>
-  <string>{{ .vpn.address }} manual</string>
+  <string>{{ .vpn.name | default .vpn.address }} manual</string>
 
   <key>PayloadIdentifier</key>
   <string>{{ .vpn.address }}.{{ .vpn.username }}.manual</string>

--- a/templates/vpn.wifi.tpl
+++ b/templates/vpn.wifi.tpl
@@ -9,7 +9,7 @@ VPN will always reconnect on this mode.
   <string>{{ .vpn.name | default .vpn.address }} Wi-Fi</string>
 
   <key>PayloadDisplayName</key>
-  <string>{{ .vpn.address }} Wi-Fi</string>
+  <string>{{ .vpn.name | default .vpn.address }} Wi-Fi</string>
 
   <key>PayloadIdentifier</key>
   <string>{{ .vpn.address }}.{{ .vpn.username }}.wifi</string>


### PR DESCRIPTION
ensure vpn.name is also used for displayname