### PR TITLE
fix: private PKCS12 certs require other values

### DIFF
--- a/templates/certs.tpl
+++ b/templates/certs.tpl
@@ -5,7 +5,7 @@ Add custom certificates to iOS profile
 {{- /* Generate list of users certificates */}}
 {{- $username := .user.username -}}
 {{- $certs := .root.Values.certs  -}}
-{{- range .root.Values.vpnserver.users -}}
+{{- range .root.Values.vpnserver.users }}
 {{- if and (eq .username $username) (.certs) }}
 {{- $certs = concat $certs .certs }}
 {{- end }}

--- a/templates/certs.tpl
+++ b/templates/certs.tpl
@@ -12,9 +12,13 @@ Add custom certificates to iOS profile
 {{- end }}
 {{- /* Template generated list of certificates */}}
 {{- range $certs }}
+{{- $certType := "pkcs1" }}
+{{- if eq "p12" ((splitList "." .filename) | last) }}
+{{- $certType = "pkcs12" }}
+{{- end }}
 <dict>
   <key>PayloadCertificateFileName</key>
-  <string>{{ regexReplaceAll "\\W+" .name "-" }}.cer</string>
+  <string>{{ .filename }}</string>
   <key>PayloadContent</key>
   <data>
     {{ ($.root.Files.Get .filename | required (printf "certificate file not fould: %s" .filename)) | b64enc }}
@@ -24,9 +28,9 @@ Add custom certificates to iOS profile
   <key>PayloadDisplayName</key>
   <string>{{ .name }}</string>
   <key>PayloadIdentifier</key>
-  <string>com.apple.security.root.{{ sha1sum (printf "cert-%s" .name) }}</string>
+  <string>com.apple.security.{{ $certType }}.{{ sha1sum (printf "cert-%s" .name) }}</string>
   <key>PayloadType</key>
-  <string>com.apple.security.root</string>
+  <string>com.apple.security.{{ $certType }}</string>
   <key>PayloadUUID</key>
   <string>{{ sha1sum (printf "cert-%s" .name) }}</string>
   <key>PayloadVersion</key>


### PR DESCRIPTION
The private certificates (.p12) requires other values to be set otherwise the cert and iOS profile can not be installed
