### PR TITLE
chore: update chart dependency vpnserver to 2.2.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -23,7 +23,7 @@ appVersion: "latest"
 dependencies:
 - alias: vpnserver
   name: ipsec-vpn-server
-  version: 2.0.0
+  version: 2.2.0
   repository: "https://helm.task.media/"
 
 icon: https://media.task.media/images/logo.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -23,7 +23,7 @@ appVersion: "latest"
 dependencies:
 - alias: vpnserver
   name: ipsec-vpn-server
-  version: 1.1.4
+  version: 2.0.0
   repository: "https://helm.task.media/"
 
 icon: https://media.task.media/images/logo.png


### PR DESCRIPTION
Update to latest `ipsec-vpn-server` subchart.