### PR TITLE
fix: use correct variable for group

### DIFF
--- a/templates/vpn.always.tpl
+++ b/templates/vpn.always.tpl
@@ -39,7 +39,7 @@ VPN will always reconnect on this mode.
 
     {{- if .vpn.group }}
     <key>LocalIdentifier</key>
-    <string>{{ .vpn.username }}</string>
+    <string>{{ .vpn.group }}</string>
 
     {{- end }}
 

--- a/templates/vpn.manual.tpl
+++ b/templates/vpn.manual.tpl
@@ -38,7 +38,7 @@ Connection can be disabled by this setting and enabled for a period of time if n
 
     {{- if .vpn.group }}
     <key>LocalIdentifier</key>
-    <string>{{ .vpn.username }}</string>
+    <string>{{ .vpn.group }}</string>
 
     {{- end }}
 

--- a/templates/vpn.wifi.tpl
+++ b/templates/vpn.wifi.tpl
@@ -39,7 +39,7 @@ VPN will always reconnect on this mode.
 
     {{- if .vpn.group }}
     <key>LocalIdentifier</key>
-    <string>{{ .vpn.username }}</string>
+    <string>{{ .vpn.group }}</string>
 
     {{- end }}
 


### PR DESCRIPTION
use correct variable for group