### PR TITLE
chore: updating trafik CRD apiVersion

### DIFF
--- a/templates/web/ingress.yaml
+++ b/templates/web/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.web.ingressroute.enabled }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: {{ include "vpn-ios-profile.fullname" . }}-web

--- a/templates/web/middleware.yaml
+++ b/templates/web/middleware.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.web.ingressroute.enabled (and .Values.web.ingressroute.username .Values.web.ingressroute.password) }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ include "vpn-ios-profile.fullname" . }}-web-basicauth


### PR DESCRIPTION
Updating to `traefik.io/v1alpha1` as its default since a while..